### PR TITLE
Major refactoring for compatibility with SCT v5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ This pipeline was tested on [SCT v3.2.5](https://github.com/neuropoly/spinalcord
 
 ## Description of the scripts
 
-* [process_data.py](./process_data.py): Process data using SCT and compute image
-quality metrics. More details [here](#analysis).
 * [simu_create_phantom.py](./simu_create_phantom.py): Generate synthetic phantom
 of WM and GM that can be used to validate the proposed evaluation metrics. The phantoms are generated with random noise,
  so running the script multiple times will not produce the same output.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ This pipeline was tested on [SCT v3.2.5](https://github.com/neuropoly/spinalcord
 
 - Download (or `git clone`) this repository.
 - Download dataset of the challenge: https://osf.io/5dqen/
-- run: `./run_pipeline.sh PATH_TO_DATA` with `PATH_TO_DATA`the path to the directory where you stored the dataset of the challenge
+- Run:
+  ```
+  sct_run_batch -script process_data.sh -j -1 -path-data <PATH_DATA> -subject-prefix "" -path-output <PATH_OUT>
+  ```
+  with
+    - PATH_DATA: The path to the downloaded dataset
+    - PATH_OUTPUT: The path where results will be output.
 
 ## Description of the scripts
 
-* [run_pipeline.sh](./run_pipeline.sh): Batch script that loops across subjects
-and process them. By default, the script will process all subjects under
-PATH_TO_DATA. If you wish to only process one subject, add the folder name as a
-2nd argument.
 * [process_data.py](./process_data.py): Process data using SCT and compute image
 quality metrics. More details [here](#analysis).
 * [simu_create_phantom.py](./simu_create_phantom.py): Generate synthetic phantom

--- a/process_data.py
+++ b/process_data.py
@@ -174,14 +174,14 @@ def main(file_input, file_seg, file_gmseg, num=None, register=True, output_dir=N
     :param verbose:
     :return: results: pandas dataframe with results
     """
-
-    # Params
-    if not output_dir:
-        output_dir = "./results"
-    file_output = "results"  # no prefix
-    fdata = ['data1.nii.gz', 'data2.nii.gz']
-    fseg = 'data1_seg.nii.gz'
-    fgmseg = 'data1_gmseg.nii.gz'
+    # 
+    # # Params
+    # if not output_dir:
+    #     output_dir = "./results"
+    # file_output = "results"  # no prefix
+    # fdata = ['data1.nii.gz', 'data2.nii.gz']
+    # fseg = 'data1_seg.nii.gz'
+    # fgmseg = 'data1_gmseg.nii.gz'
 
     # Parse arguments
     # if not args:
@@ -192,64 +192,64 @@ def main(file_input, file_seg, file_gmseg, num=None, register=True, output_dir=N
     # register = args.register
     # num = args.num
     # verbose = args.verbose
+    # 
+    # # Make output dir
+    # if not os.path.isdir(output_dir):
+    #     os.makedirs(output_dir)
+    # 
+    # # copy to output directory and convert to nii.gz
+    # print("Copy data...")
+    # sct.copy(file_input[0], os.path.join(output_dir, fdata[0]))
+    # if os.path.isfile(file_input[1]):
+    #     sct.copy(file_input[1], os.path.join(output_dir, fdata[1]))
+    #     run_diff_method = True
+    # else:
+    #     run_diff_method = False
+    # if file_seg is not None:
+    #     sct.copy(file_seg, os.path.join(output_dir, fseg))
+    # if file_gmseg is not None:
+    #     sct.copy(file_gmseg, os.path.join(output_dir, fgmseg))
+    # 
+    # # move to results directory
+    # curdir = os.getcwd()
+    # os.chdir(output_dir)
+    # 
+    # # Segment spinal cord
+    # if file_seg is None:
+    #     print("Segment spinal cord...")
+    #     sct.run("sct_deepseg_sc -i " + fdata[0] + " -c t2s", verbose=verbose)
+    # 
+    # # Segment gray matter
+    # if file_gmseg is None:
+    #     print("Segment gray matter...")
+    #     sct.run("sct_deepseg_gm -i " + fdata[0], verbose=verbose)
 
-    # Make output dir
-    if not os.path.isdir(output_dir):
-        os.makedirs(output_dir)
+    # # Crop data (for faster processing)
+    # print("Crop data (for faster processing)...")
+    # sct.run("sct_create_mask -i " + fdata[0] + " -p centerline," + fseg + " -size 35mm", verbose=verbose)
+    # fmask = "mask_" + fdata[0]
+    # sct.run("sct_crop_image -i " + fdata[0] + " -m " + fmask + " -o " + sct.add_suffix(fdata[0], 'c'))
+    # fdata[0] = sct.add_suffix(fdata[0], 'c')
+    # sct.run("sct_crop_image -i " + fseg + " -m " + fmask + " -o " + sct.add_suffix(fseg, 'c'))
+    # fseg = sct.add_suffix(fseg, 'c')
+    # sct.run("sct_crop_image -i " + fgmseg + " -m " + fmask + " -o " + sct.add_suffix(fgmseg, 'c'))
+    # fgmseg = sct.add_suffix(fgmseg, 'c')
+    # 
+    # # Generate white matter segmentation
+    # print("Generate white matter segmentation...")
+    # sct.run("sct_maths -i " + fseg + " -sub " + fgmseg + " -o " + fdata[0] + "_wmseg.nii.gz", verbose=verbose)
+    # 
+    # # Erode white matter mask to minimize partial volume effect
+    # # Note: we cannot erode the gray matter because it is too thin (most of the time, only one voxel)
+    # print("Erode white matter mask...")
+    # sct.run("sct_maths -i " + fdata[0] + "_wmseg.nii.gz -erode 1 -o " + fdata[0] + "_wmseg_erode.nii.gz", verbose=verbose)
 
-    # copy to output directory and convert to nii.gz
-    print("Copy data...")
-    sct.copy(file_input[0], os.path.join(output_dir, fdata[0]))
-    if os.path.isfile(file_input[1]):
-        sct.copy(file_input[1], os.path.join(output_dir, fdata[1]))
-        run_diff_method = True
-    else:
-        run_diff_method = False
-    if file_seg is not None:
-        sct.copy(file_seg, os.path.join(output_dir, fseg))
-    if file_gmseg is not None:
-        sct.copy(file_gmseg, os.path.join(output_dir, fgmseg))
-
-    # move to results directory
-    curdir = os.getcwd()
-    os.chdir(output_dir)
-
-    # Segment spinal cord
-    if file_seg is None:
-        print("Segment spinal cord...")
-        sct.run("sct_deepseg_sc -i " + fdata[0] + " -c t2s", verbose=verbose)
-
-    # Segment gray matter
-    if file_gmseg is None:
-        print("Segment gray matter...")
-        sct.run("sct_deepseg_gm -i " + fdata[0], verbose=verbose)
-
-    # Crop data (for faster processing)
-    print("Crop data (for faster processing)...")
-    sct.run("sct_create_mask -i " + fdata[0] + " -p centerline," + fseg + " -size 35mm", verbose=verbose)
-    fmask = "mask_" + fdata[0]
-    sct.run("sct_crop_image -i " + fdata[0] + " -m " + fmask + " -o " + sct.add_suffix(fdata[0], 'c'))
-    fdata[0] = sct.add_suffix(fdata[0], 'c')
-    sct.run("sct_crop_image -i " + fseg + " -m " + fmask + " -o " + sct.add_suffix(fseg, 'c'))
-    fseg = sct.add_suffix(fseg, 'c')
-    sct.run("sct_crop_image -i " + fgmseg + " -m " + fmask + " -o " + sct.add_suffix(fgmseg, 'c'))
-    fgmseg = sct.add_suffix(fgmseg, 'c')
-
-    # Generate white matter segmentation
-    print("Generate white matter segmentation...")
-    sct.run("sct_maths -i " + fseg + " -sub " + fgmseg + " -o " + fdata[0] + "_wmseg.nii.gz", verbose=verbose)
-
-    # Erode white matter mask to minimize partial volume effect
-    # Note: we cannot erode the gray matter because it is too thin (most of the time, only one voxel)
-    print("Erode white matter mask...")
-    sct.run("sct_maths -i " + fdata[0] + "_wmseg.nii.gz -erode 1 -o " + fdata[0] + "_wmseg_erode.nii.gz", verbose=verbose)
-
-    if run_diff_method and register:
-        print("Register data2 to data1...")
-        # Register image 2 to image 1
-        sct.run("sct_register_multimodal -i " + fdata[1] + " -d " + fdata[0] + " -param step=2,type=im,algo=rigid,metric=MeanSquares,smooth=1,iter=50,slicewise=1 -x nn", verbose=verbose)
-        # Add suffix to file name
-        fdata[1] = sct.add_suffix(fdata[1], "_reg")
+    # if run_diff_method and register:
+    #     print("Register data2 to data1...")
+    #     # Register image 2 to image 1
+    #     sct.run("sct_register_multimodal -i " + fdata[1] + " -d " + fdata[0] + " -param step=2,type=im,algo=rigid,metric=MeanSquares,smooth=1,iter=50,slicewise=1 -x nn", verbose=verbose)
+    #     # Add suffix to file name
+    #     fdata[1] = sct.add_suffix(fdata[1], "_reg")
 
     # Analysis: compute metrics
     # Initialize data frame for reporting results

--- a/process_data.sh
+++ b/process_data.sh
@@ -123,6 +123,10 @@ sct_maths -i ${file_1}_wmseg${ext} -erode 1 -o ${file_1}_wmseg_erode${ext}
 # Note: We use NearestNeighboor for final interpolation to not alter noise distribution
 sct_register_multimodal -i ${file_2}${ext} -d ${file_1}${ext} -dseg ${file_1_seg}${ext} -param step=1,type=im,algo=rigid,metric=MeanSquares,smooth=1,slicewise=1,iter=50 -x nn -qc ${PATH_QC} -qc-subject ${SUBJECT}
 file_2=${file_2}_reg
+# Compute SNR using both methods
+sct_image -i ${file_1}${ext} ${file_2}${ext} -concat t -o data_concat.nii.gz
+sct_compute_snr -i data_concat.nii.gz -method diff -m data1_crop_wmseg_erode.nii.gz > snr_diff.txt 
+sct_compute_snr -i data_concat.nii.gz -method mult -m data1_crop_wmseg_erode.nii.gz > snr_mult.txt
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------

--- a/process_data.sh
+++ b/process_data.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Process data.
+#
+# Usage:
+#   ./process_data.sh <SUBJECT>
+#
+# Manual segmentations or labels should be located under:
+# <SUBJECT>/
+#
+# Authors: Julien Cohen-Adad
+
+# The following global variables are retrieved from the caller sct_run_batch
+# but could be overwritten by uncommenting the lines below:
+# PATH_DATA_PROCESSED="~/data_processed"
+# PATH_RESULTS="~/results"
+# PATH_LOG="~/log"
+# PATH_QC="~/qc"
+
+# Uncomment for full verbose
+set -x
+
+# Immediately exit if error
+set -e -o pipefail
+
+# Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
+trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
+
+# Retrieve input params
+SUBJECT=$1
+
+# get starting time:
+start=`date +%s`
+
+
+# FUNCTIONS
+# ==============================================================================
+
+# Check if manual segmentation already exists. If it does, copy it locally. If
+# it does not, perform seg.
+segment_if_does_not_exist(){
+  local file="$1"
+  local contrast="$2"
+  # Find contrast
+  if [[ $contrast == "dwi" ]]; then
+    folder_contrast="dwi"
+  else
+    folder_contrast="anat"
+  fi
+  # Update global variable with segmentation file name
+  FILESEG="${file}_seg"
+  FILESEGMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/${folder_contrast}/${FILESEG}-manual.nii.gz"
+  echo
+  echo "Looking for manual segmentation: $FILESEGMANUAL"
+  if [[ -e $FILESEGMANUAL ]]; then
+    echo "Found! Using manual segmentation."
+    rsync -avzh $FILESEGMANUAL ${FILESEG}.nii.gz
+    sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  else
+    echo "Not found. Proceeding with automatic segmentation."
+    # Segment spinal cord
+    sct_deepseg_sc -i ${file}.nii.gz -c $contrast -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  fi
+}
+
+# Check if manual segmentation already exists. If it does, copy it locally. If
+# it does not, perform seg.
+segment_gm_if_does_not_exist(){
+  local file="$1"
+  local contrast="$2"
+  # Update global variable with segmentation file name
+  FILESEG="${file}_gmseg"
+  FILESEGMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/anat/${FILESEG}-manual.nii.gz"
+  echo "Looking for manual segmentation: $FILESEGMANUAL"
+  if [[ -e $FILESEGMANUAL ]]; then
+    echo "Found! Using manual segmentation."
+    rsync -avzh $FILESEGMANUAL ${FILESEG}.nii.gz
+    sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_gm -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  else
+    echo "Not found. Proceeding with automatic segmentation."
+    # Segment spinal cord
+    sct_deepseg_gm -i ${file}.nii.gz -qc ${PATH_QC} -qc-subject ${SUBJECT}
+  fi
+}
+
+
+
+# SCRIPT STARTS HERE
+# ==============================================================================
+# Display useful info for the log, such as SCT version, RAM and CPU cores available
+sct_check_dependencies -short
+
+# Go to folder where data will be copied and processed
+cd $PATH_DATA_PROCESSED
+# Copy source images
+rsync -avzh $PATH_DATA/$SUBJECT .
+# Go to anat folder where all structural data are located
+cd ${SUBJECT}
+
+file_1="data1"
+# Segment spinal cord
+segment_if_does_not_exist $file_1 "t2s"
+file_1_seg=$FILESEG
+# Segment gray matter
+segment_gm_if_does_not_exist $file_1
+file_1_seg=$FILESEG
+
+# Verify presence of output files and write log file if error
+# ------------------------------------------------------------------------------
+FILES_TO_CHECK=(
+  "data1_seg_manual.nii.gz"
+  "data1_gmseg_manual.nii.gz"
+)
+for file in ${FILES_TO_CHECK[@]}; do
+  if [[ ! -e $file ]]; then
+    echo "${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
+  fi
+done
+
+# Display useful info for the log
+end=`date +%s`
+runtime=$((end-start))
+echo
+echo "~~~"
+echo "SCT version: `sct_version`"
+echo "Ran on:      `uname -nsr`"
+echo "Duration:    $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($runtime % 60))sec"
+echo "~~~"

--- a/process_data.sh
+++ b/process_data.sh
@@ -127,6 +127,13 @@ file_2=${file_2}_reg
 sct_image -i ${file_1}${ext} ${file_2}${ext} -concat t -o data_concat.nii.gz
 sct_compute_snr -i data_concat.nii.gz -method diff -m data1_crop_wmseg_erode.nii.gz > snr_diff.txt 
 sct_compute_snr -i data_concat.nii.gz -method mult -m data1_crop_wmseg_erode.nii.gz > snr_mult.txt
+# Compute average value in WM and GM to subsequently compute contrast
+sct_extract_metric -i ${file_1}${ext} -f ${file_1}_wmseg${ext} -method bin -o signal_wm.csv
+sct_extract_metric -i ${file_2}${ext} -f ${file_1}_wmseg${ext} -method bin -o signal_wm.csv -append 1
+sct_extract_metric -i ${file_1}${ext} -f ${file_1_gmseg}${ext} -method bin -o signal_gm.csv
+sct_extract_metric -i ${file_2}${ext} -f ${file_1_gmseg}${ext} -method bin -o signal_gm.csv -append 1
+sct.run("sct_extract_metric -i " + file_data + " -f " + file_mask2 + " -method bin -o mean_mask2.pickle")
+
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------
@@ -134,6 +141,8 @@ FILES_TO_CHECK=(
   "data1_seg_manual${ext}"
 	"data1_gmseg_manual${ext}"
 	"data1_crop_wmseg_erode${ext}"
+	"signal_wm.csv"
+	"signal_gm.csv"
 )
 for file in ${FILES_TO_CHECK[@]}; do
   if [[ ! -e $file ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -141,6 +141,8 @@ FILES_TO_CHECK=(
 	"data1_crop_wmseg_erode${ext}"
 	"signal_wm.csv"
 	"signal_gm.csv"
+  "snr_diff.txt"
+  "snr_mult.txt"
 )
 for file in ${FILES_TO_CHECK[@]}; do
   if [[ ! -e $file ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -132,8 +132,6 @@ sct_extract_metric -i ${file_1}${ext} -f ${file_1}_wmseg${ext} -method bin -o si
 sct_extract_metric -i ${file_2}${ext} -f ${file_1}_wmseg${ext} -method bin -o signal_wm.csv -append 1
 sct_extract_metric -i ${file_1}${ext} -f ${file_1_gmseg}${ext} -method bin -o signal_gm.csv
 sct_extract_metric -i ${file_2}${ext} -f ${file_1_gmseg}${ext} -method bin -o signal_gm.csv -append 1
-sct.run("sct_extract_metric -i " + file_data + " -f " + file_mask2 + " -method bin -o mean_mask2.pickle")
-
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Major refactoring, which includes the following changes:

- Pipeline now relying on SCT v5.3.0 (previously it was v3.2.5)
- Pipeline is ran using `sct_run_batch`. This implied major changes, including creating a SHELL wrapper. #44 
- Updated documentation

TODO in subsequent PRs:
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3453 needs to be fixed so that SNR results can conveniently be retrieved by the Python statistics file. https://github.com/sct-pipeline/gm-challenge/issues/50
- Write a Python script that computes the contrast by doing the slicewise ratio between each row of `signal_gm.csv` and `signal_wm.csv` files that are generated by the `process_data.sh` script. https://github.com/sct-pipeline/gm-challenge/issues/49
- Update script to compute statistics and generate figures. https://github.com/sct-pipeline/gm-challenge/issues/51